### PR TITLE
Limit the amount of nesting of [] elements and add a parsing timeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pegdown"
 
-version := "1.4.2"
+version := "1.4.2-atlassian-1"
 
 homepage := Some(new URL("http://pegdown.org"))
 
@@ -57,15 +57,15 @@ useGpg := true
 pgpSigningKey := Some(-2321133875171851978L)
 
 publishTo <<= version { v: String =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
-  else                             Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  val nexus = "https://maven.atlassian.com"
+  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "/public-snapshot")
+  else                             Some("releases" at nexus + "/public")
 }
 
 pomExtra :=
   <scm>
-    <url>git@github.com:sirthias/pegdown.git</url>
-    <connection>scm:git:git@github.com:sirthias/pegdown.git</connection>
+    <url>git@github.com:atlassian/pegdown.git</url>
+    <connection>scm:git:git@github.com:atlassian/pegdown.git</connection>
   </scm>
   <developers>
     <developer>

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pegdown"
 
-version := "1.4.2-atlassian-1"
+version := "1.4.2-atlassian-2-SNAPSHOT"
 
 homepage := Some(new URL("http://pegdown.org"))
 
@@ -42,6 +42,8 @@ resolvers += Opts.resolver.sonatypeReleases
 
 // publishing
 
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
 crossPaths := false
 
 autoScalaLibrary := false
@@ -58,8 +60,8 @@ pgpSigningKey := Some(-2321133875171851978L)
 
 publishTo <<= version { v: String =>
   val nexus = "https://maven.atlassian.com"
-  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "/public-snapshot")
-  else                             Some("releases" at nexus + "/public")
+  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "/3rdparty-snapshot")
+  else                             Some("releases" at nexus + "/3rdparty")
 }
 
 pomExtra :=

--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -975,6 +975,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
     public Rule Label() {
         return Sequence(
                 '[',
+                checkForParsingTimeout(),
                 push(new SuperNode()),
                 OneOrMore(TestNot(']'), NonAutoLinkInline(), addAsChild()),
                 ']'

--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -26,6 +26,7 @@ import org.parboiled.common.ArrayBuilder;
 import org.parboiled.common.ImmutableList;
 import org.parboiled.parserunners.ParseRunner;
 import org.parboiled.parserunners.ReportingParseRunner;
+import org.parboiled.support.MatcherPath;
 import org.parboiled.support.ParsingResult;
 import org.parboiled.support.StringBuilderVar;
 import org.parboiled.support.StringVar;
@@ -974,6 +975,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
 
     public Rule Label() {
         return Sequence(
+                checkNoDeeplyNestedLabels(),
                 '[',
                 checkForParsingTimeout(),
                 push(new SuperNode()),
@@ -1494,6 +1496,19 @@ public class Parser extends BaseParser<Object> implements Extensions {
     ParsingResult<Node> parseToParsingResult(char[] source) {
         parsingStartTimeStamp = System.currentTimeMillis();
         return parseRunnerProvider.get(Root()).run(source);
+    }
+
+    protected boolean checkNoDeeplyNestedLabels() {
+        int labels = 0;
+        MatcherPath path = getContext().getPath();
+        while (path != null) {
+            if (path.element.matcher.getLabel().equals("Label")) {
+                ++labels;
+            }
+            path = path.parent;
+        }
+        // allow up to 3 levels of labels
+        return labels < 4;
     }
 
     protected boolean checkForParsingTimeout() {

--- a/src/main/java/org/pegdown/ToHtmlSerializer.java
+++ b/src/main/java/org/pegdown/ToHtmlSerializer.java
@@ -264,7 +264,6 @@ public class ToHtmlSerializer implements Visitor {
         printIndentedTag(node, "tbody");
     }
 
-    @Override
     public void visit(TableCaptionNode node) {
         printer.println().print("<caption>");
         visitChildren(node);

--- a/src/test/scala/org/pegdown/PathologicalInputSpec.scala
+++ b/src/test/scala/org/pegdown/PathologicalInputSpec.scala
@@ -28,6 +28,13 @@ class PathologicalInputSpec extends AbstractPegDownSpec {
       } mustNotEqual null
     }
 
+    "properly parse pathological input example 3" in {
+      new PegDownProcessor(200l).markdownToHtml {
+        "how about a new method thats getObjectIdOrAdjustmentGroup? That w[a[[[[[[[[[[[[[[[[[y we're more explicit" +
+          " and still benefit callers from having to do the iff dance"
+      } must throwA[org.parboiled.errors.ParserRuntimeException]
+    }
+
   }
 
 }

--- a/src/test/scala/org/pegdown/PathologicalInputSpec.scala
+++ b/src/test/scala/org/pegdown/PathologicalInputSpec.scala
@@ -29,12 +29,18 @@ class PathologicalInputSpec extends AbstractPegDownSpec {
     }
 
     "properly parse pathological input example 3" in {
-      new PegDownProcessor(200l).markdownToHtml {
+      new PegDownProcessor(2000l).markdownToHtml {
         "how about a new method thats getObjectIdOrAdjustmentGroup? That w[a[[[[[[[[[[[[[[[[[y we're more explicit" +
           " and still benefit callers from having to do the iff dance"
-      } must throwA[org.parboiled.errors.ParserRuntimeException]
+      } mustEqual "<p>how about a new method thats getObjectIdOrAdjustmentGroup? That w[a[[[[[[[[[[[[[[[[[y we're more explicit" +
+        " and still benefit callers from having to do the iff dance</p>"
     }
 
+    "properly parse pathological input example 4" in {
+      new PegDownProcessor(2000l).markdownToHtml {
+        "[Just a [URL](/url/) preceded by an unbalanced bracket."
+      } mustEqual "<p>[Just a <a href=\"/url/\">URL</a> preceded by an unbalanced bracket.</p>"
+    }
   }
 
 }


### PR DESCRIPTION
The parsing timeout prevents the parser from going into a tail spin when it encounters pathological cases with lots of unbalanced `[` characters in things like ASCII art.

The downside of the parsing timeout is that the markdown rendering fails with an exception. 

The limit on the nesting of labels prevents the parser from going into a tail spin to begin with. It still allows nested labels in markdown such as 

```
[Something in brackets like [this][] should work]
```

but prevents the parser from going down the rabbit hole when there are lots and lots of unbalanced `[` characters.
